### PR TITLE
Improved main loop blocking with no internet connection

### DIFF
--- a/src/AsyncTelegram2.cpp
+++ b/src/AsyncTelegram2.cpp
@@ -131,7 +131,7 @@ bool AsyncTelegram2::getUpdates(){
         m_lastUpdateTime = millis();
 
         // If previuos reply from server was received (and parsed)
-        if( m_waitingReply == false ) {
+        if( m_waitingReply == false && telegramClient->connected()) {
             char payload[BUFFER_SMALL];
             snprintf(payload, BUFFER_SMALL, "{\"limit\":1,\"timeout\":0,\"offset\":%d}", m_lastUpdateId);
             sendCommand("getUpdates", payload);


### PR DESCRIPTION
Fixed (improved) main loop blocking while calling myBot.getNewMessage without internet connection (e.g cable unplugged from the WAN port of a router, but Wi-Fi still presented).

There is till some blocking around 16 secs of duration each 10*m_minUpdateTime because of invoking reset(); but at least not each loop() iteration :)
The 16 sec block is caused by WiFiClientSecure::connect function, which also seems to be known issue 
https://github.com/espressif/arduino-esp32/pull/5418

Tested on esp8266 but perhaps should be similar behavior on esp32.