### PR TITLE
make OTA works for ESP32

### DIFF
--- a/src/AsyncTelegram2.cpp
+++ b/src/AsyncTelegram2.cpp
@@ -95,18 +95,32 @@ bool AsyncTelegram2::sendCommand(const char *command, const char *payload, bool 
         // Blocking mode
         if (blocking)
         {
-            if (!telegramClient->find((char *)HEADERS_END))
+            bool close_connection = false;
+            uint16_t len = 0, pos = 0;
+            // Skip headers
+            while (telegramClient->connected())
             {
-                log_error("Invalid HTTP response");
-                telegramClient->stop();
-                return false;
+                String line = telegramClient->readStringUntil('\n');
+                if (line == "\r")
+                    break;
+                if (line.indexOf("close") > -1)
+                {
+                    close_connection = true;
+                }
+                if (line.indexOf("Content-Length:") > -1)
+                {
+                    len = line.substring(strlen("Content-Length: ")).toInt();
+                }
             }
-            // If there are incoming bytes available from the server, read them and print them:
-            m_rxbuffer = "";
-            while (telegramClient->available())
+            m_rxbuffer.clear();
+            // If there are incoming bytes available from the server, read them and store:
+            for (uint32_t timeout = millis(); (millis() - timeout > 1000) || pos < len;)
             {
-                yield();
-                m_rxbuffer += (char)telegramClient->read();
+                if (telegramClient->available())
+                {
+                    m_rxbuffer += (char)telegramClient->read();
+                    pos++;
+                }
             }
             m_waitingReply = false;
             if (m_rxbuffer.indexOf("\"ok\":true") > -1)


### PR DESCRIPTION
it looks that `telegramClient->find` get blocking on ESP32, in my OTA update, it always cannot read getFile command properly, and result an error.

## Type of change:

make block sendCommand read response like other parts.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [ ] merged with the current development branch (before testing)
- [ ] CI build finished without issues
- [x] Tested on real hardware (List board here): ESP32-C3, ESP8266
- [ ] Changes are backward compatible

## Checklist:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

<!-- https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md --> 