### PR TITLE
Added support to mimetypes TEXT and BINARY, fixed missing VOICE stream type

### DIFF
--- a/src/AsyncTelegram2.cpp
+++ b/src/AsyncTelegram2.cpp
@@ -664,8 +664,12 @@ bool AsyncTelegram2::sendDocument(int64_t chat_id, Stream &stream, size_t size,
         return sendStream(chat_id, "sendPhoto", "image/jpeg", "photo", stream, size, filename, caption);
     case AUDIO:
         return sendStream(chat_id, "sendDocument", "audio/mp3", "audio", stream, size, filename, caption);
-    default:
+    case VOICE:
+        return sendStream(chat_id, "sendVoice", "audio/ogg", "voice", stream, size, filename, caption);
+    case TEXT:
         return sendStream(chat_id, "sendDocument", "text/plain", "document", stream, size, filename, caption);
+    default: // BINARY
+        return sendStream(chat_id, "sendDocument", "application/octet-stream", "document", stream, size, filename, caption);
     }
 
     return false;

--- a/src/AsyncTelegram2.h
+++ b/src/AsyncTelegram2.h
@@ -208,7 +208,9 @@ public:
         VOICE,
         VIDEO,
         CSV,
-        JSON
+        JSON,
+        TEXT,
+        BINARY
     };
     bool sendDocument(int64_t chat_id, Stream &stream, size_t size,
                         DocumentType doc, const char *filename, const char *caption = nullptr);


### PR DESCRIPTION
The code is pretty clear, I added support to more mime types. In particular the support was added for generic binary file and plain text. Added also the call to sendVoice for voice messages.