### PR TITLE
Do not expose logger macros

### DIFF
--- a/src/AsyncTelegram2.cpp
+++ b/src/AsyncTelegram2.cpp
@@ -1,4 +1,5 @@
 #include "AsyncTelegram2.h"
+#include "serial_log.h"
 
 #define HEADERS_END "\r\n\r\n"
 

--- a/src/AsyncTelegram2.h
+++ b/src/AsyncTelegram2.h
@@ -55,7 +55,6 @@
 #include "DataStructures.h"
 #include "InlineKeyboard.h"
 #include "ReplyKeyboard.h"
-#include "serial_log.h"
 
 #define TELEGRAM_HOST "api.telegram.org"
 #define TELEGRAM_IP "149.154.167.220"

--- a/src/ReplyKeyboard.cpp
+++ b/src/ReplyKeyboard.cpp
@@ -1,4 +1,5 @@
 #include "ReplyKeyboard.h"
+#include "serial_log.h"
 
 ReplyKeyboard::ReplyKeyboard(size_t size)
 {

--- a/src/ReplyKeyboard.h
+++ b/src/ReplyKeyboard.h
@@ -6,7 +6,6 @@
 #define ARDUINOJSON_DECODE_UNICODE  1
 #include <ArduinoJson.h>
 #include "DataStructures.h"
-#include "serial_log.h"
 
 #if ARDUINOJSON_VERSION_MAJOR > 6
     #define JSON_DOC(x) JsonDocument root


### PR DESCRIPTION
## Description:

The logger macros like ```ĺog_debg``` are visible to application code that uses this library. This may collide with similar macro definitions already present in the application.

This PR hides these macro definitions so that name collisions are avoided and different loggers that use the same macro identifiers can co-exist. 

**Assumption**: It is not intended to make the logger available to the application.

## Type of change:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:

- [ ] merged with the current development branch (before testing)
- [ ] CI build finished without issues
- [X] Tested on real hardware: Rpi Pico 2W
- [X] Changes are backward compatible

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
